### PR TITLE
getLSBIndex: Replace PoT lookup table with Math.clz32

### DIFF
--- a/utilities.ts
+++ b/utilities.ts
@@ -1,42 +1,4 @@
 /**
- * Lookup table for powers of 2
- */
-export const log2: Record<number, number> = {
-  1: 0,
-  2: 1,
-  4: 2,
-  8: 3,
-  16: 4,
-  32: 5,
-  64: 6,
-  128: 7,
-  256: 8,
-  512: 9,
-  1024: 10,
-  2048: 11,
-  4096: 12,
-  8192: 13,
-  16384: 14,
-  32768: 15,
-  65536: 16,
-  131072: 17,
-  262144: 18,
-  524288: 19,
-  1048576: 20,
-  2097152: 21,
-  4194304: 22,
-  8388608: 23,
-  16777216: 24,
-  33554432: 25,
-  67108864: 26,
-  134217728: 27,
-  268435456: 28,
-  536870912: 29,
-  1073741824: 30,
-  2147483648: 31,
-};
-
-/**
  * Counts set bits in a given number.
  *
  * @param value the number
@@ -55,8 +17,7 @@ export function popCount32(value: number): number {
  * @return the index of LSB
  */
 export function getLSBIndex(value: number): number {
-  if (value === 2147483648) return 31;
-  return log2[value & -value];
+  return 31 - Math.clz32(value & -value);
 }
 
 /**


### PR DESCRIPTION
The lookup table approach is really neat, but after running some benchmarks it looks like we can get a ~10-15x speedup by using the built-in `Math.clz32()`

### Benchmark

```
let n = 2;
for (let i = 0; i < 16; i++) {
	getLSBIndex(n);
	n *= 2;
}
```

#### Chrome 119
| Approach  | Second Header |
| ------------- | ------------- |
| **Math.clz32**  | 145M ops/s ± 0.48%  |
| **Lookup table**  | 9.8M ops/s  ± 0.24% _(93.21% slower)_  |

#### Safari 17.9
| Approach  | Second Header |
| ------------- | ------------- |
| **Math.clz32**  | 120M ops/s  ± 0.24%  |
| **Lookup table**  | 12M ops/s  ± 0.51%.  _(89.76% slower)_  |


[Math.clz32() Browser support](https://caniuse.com/mdn-javascript_builtins_math_clz32)